### PR TITLE
Change makeVM.sh to accept comments after the vbox name

### DIFF
--- a/makeVM/makeVM.sh
+++ b/makeVM/makeVM.sh
@@ -16,7 +16,7 @@ vboxmanage snapshot ${VMNAME} restore ${STARTSNAPSHOT}
 vboxmanage controlvm ${VMNAME} acpipowerbutton
 sleep 2
 
-for module in `cat modules.txt | grep -v "#"`; do
+for module in `cat modules.txt | grep -v "^#"`; do
   echo "Running module ${module}..."
   modules/${module}
   sleep 10 


### PR DESCRIPTION
This will accept comments in the same line as the module name. Here is an example to illustrate what I mean:
```
$ cat t
#bla
bla#
bla
$ grep -v '#' t
bla
$ grep -v '^#' t
bla#
bla
```