### PR TITLE
adjust modules.txt to match readme

### DIFF
--- a/makeVM/modules.txt
+++ b/makeVM/modules.txt
@@ -1,12 +1,12 @@
 ssh.sh
-#lemp.sh
-#dre.sh
+lemp.sh
+dre.sh
 
 
-# log poisoning module 
-# only enable ssh.sh & init_log_poison.sh
-init_log_poison.sh
+#log poisoning module 
+#only enable ssh.sh & init_log_poison.sh
+#init_log_poison.sh
 
-docker.sh
-phpmyadmin.sh
-1a-akademie.sh
+#docker.sh
+#phpmyadmin.sh
+#1a-akademie.sh


### PR DESCRIPTION
Adjust `modules.txt` to match `readme` description. Basically trying to avoid confusion during installation / first setup process.